### PR TITLE
Remove note about `_.pluck`.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -556,17 +556,7 @@ myfun(123, function(err, ret) {
 
 ## Lodash
 
-Use `_.map` instead of `_.pluck`
-
-Right:
-```
-_.map([{a: 1}, {a: 2}], 'a');
-```
-
-Wrong:
-```
-_.pluck([{a: 1}, {a: 2}], 'a');
-```
+Use it, Lodash is great.
 
 ## Multi-line function calls
 


### PR DESCRIPTION
See: https://github.com/lodash/lodash/wiki/Changelog#v400

> Removed `_.pluck` in favor of `_.map` with iteratee shorthand